### PR TITLE
セキュリティ対応のために依存ライブラリのバージョンアップデート

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -1,6 +1,13 @@
+# MEMO: googleauthのgem更新のPRに合わせた対応を実施
+# https://github.com/gimite/google-drive-ruby/pull/419
+#
+# このライブラリが依存しているGoogle APIのgem(drive/sheet)が、依存しているgem(google-apis-core)の設定に合わせるようにする
+# https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-drive_v3/google-apis-drive_v3.gemspec
+# https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/google-apis-sheets_v4.gemspec
+# https://github.com/googleapis/google-api-ruby-client/blob/main/google-apis-core/google-apis-core.gemspec#L22-L29
 Gem::Specification.new do |s|
   s.name = 'google_drive'
-  s.version = '3.0.7'
+  s.version = '3.0.7.1'
   s.authors = ['Hiroshi Ichikawa']
   s.email = ['gimite+github@gmail.com']
   s.summary = 'A library to read/write files/spreadsheets in Google Drive/Docs.'
@@ -8,15 +15,15 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/gimite/google-drive-ruby'
   s.rubygems_version = '1.2.0'
   s.license = 'BSD-3-Clause'
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.7'
 
   s.files = ['README.md'] + Dir['lib/**/*']
   s.require_paths = ['lib']
 
   s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
-  s.add_dependency('google-apis-drive_v3', '>= 0.5.0', '< 1.0.0')
-  s.add_dependency('google-apis-sheets_v4', '>= 0.4.0', '< 1.0.0')
-  s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
+  s.add_dependency('google-apis-drive_v3', '>= 0.5.0', '< 2.0.0')
+  s.add_dependency('google-apis-sheets_v4', '>= 0.4.0', '< 2.0.0')
+  s.add_dependency('googleauth', ['>= 0.5.0', '< 2.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])
   s.add_development_dependency('rake', ['>= 0.8.0'])
   s.add_development_dependency('rspec-mocks', ['>= 3.4.0', '< 4.0.0'])


### PR DESCRIPTION
## 概要

弊社が使用しているGoogleDrive/SpreasSheetのgemは、公式のgemを使用しているわけではなく、サードパーティが作ったgemになっています
そのgemがメンテされておらず、特に認証・認可部分のライブラリアップデートのPRが滞っています
https://github.com/gimite/google-drive-ruby/pull/419

この結果、弊社が使用しているGoogle APIのgem、または関連するgemが軒並みアップデート不可能という状況に陥っています
本来であれば、メンテがされていないためにこのgemを外して公式のものに対応するのが一番良いですが、
まずはこのgemをforkして、件のPR内容を取り込めるようにします
こうすることで、他のGoogle APIのgemをアップデートできるようにします

ライセンスとしても修正BSDなので、この改修によって特に大きな影響は無い(バイナリにして再配布もしない)です

## やったこと

- fork対応
- 前述のPR内容の取り込み対応
-  RubyのバージョンをGoogle Drive/SpreadSheetのgemに合わせる

\#  この内容を取り込み次第、linebot-service側の対応も行います

## チケット

https://www.notion.so/pharma-x/google_drive-gem-5e7851dd85db45939d352b323f680b39
